### PR TITLE
Remove the "provider" client

### DIFF
--- a/pdm-ui/Settings-Example.plist
+++ b/pdm-ui/Settings-Example.plist
@@ -4,10 +4,6 @@
 <dict>
 	<key>RootURL</key>
 	<string>http://localhost:3000/</string>
-	<key>ClientID</key>
-	<string>CLIENT ID HERE</string>
-	<key>ClientSecret</key>
-	<string>CLIENT SECRET HERE</string>
 	<key>AutoLogin</key>
 	<false/>
 	<key>DisableHealthKit</key>

--- a/pdm-ui/ViewControllers/InitializePDMViewController.swift
+++ b/pdm-ui/ViewControllers/InitializePDMViewController.swift
@@ -82,31 +82,7 @@ class InitializePDMViewController: UIViewController {
                     return
                 }
                 // Now that we have the profile, we can send whatever we have from HealthKit (assuming HealthKit is available)
-                self.doFhirClientLogin()
-            }
-        }
-    }
-
-    func doFhirClientLogin() {
-        guard let pdm = patientDataManager else {
-            pdmNotAvailable()
-            return
-        }
-        guard pdm.healthKit != nil else {
-            // Skip this step
-            loadHealthRecords()
-            return
-        }
-        showSendingHealthKit("Logging in to PDM...")
-        pdm.fhirClientLogin() { error in
-            DispatchQueue.main.async {
-                if let error = error {
-                    // This means we couldn't log in as a FHIR client. This should be handled in some fashion but for now, skip ahead
-                    print("Could not log in as a FHIR client: \(error)")
-                    self.loadHealthRecords()
-                } else {
-                    self.sendHealthKitRecords()
-                }
+                self.sendHealthKitRecords()
             }
         }
     }


### PR DESCRIPTION
This removes the need to have a special "provider" client built in to every copy of the PDM app. With the changes merged to pdm-backend to allow user accounts to upload their own records, it is no longer necessary.