### PR TITLE
added password complexity guards

### DIFF
--- a/pdm-ui.xcodeproj/project.pbxproj
+++ b/pdm-ui.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		2E3C3349229892DD0013A712 /* PDMMiniBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E3C3348229892DD0013A712 /* PDMMiniBrowserViewController.swift */; };
 		2E40233022B7DE4500E525C7 /* PDMBorderedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E40232F22B7DE4400E525C7 /* PDMBorderedView.swift */; };
 		2E4A2AB62326C26F0019C6A8 /* PDMUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4A2AB52326C26F0019C6A8 /* PDMUserTests.swift */; };
+		2E4A2AB82326CC6C0019C6A8 /* CreateAccountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4A2AB72326CC6C0019C6A8 /* CreateAccountTests.swift */; };
 		2E5088F22267B6DA009FF808 /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5088F12267B6DA009FF808 /* WelcomeViewController.swift */; };
 		2E5088F6226908BD009FF808 /* PDMCheckbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5088F5226908BD009FF808 /* PDMCheckbox.swift */; };
 		2E53B95422A176E800202ACD /* PatientHealthRecordDataController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53B95322A176E800202ACD /* PatientHealthRecordDataController.swift */; };
@@ -110,6 +111,7 @@
 		2E3C3348229892DD0013A712 /* PDMMiniBrowserViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDMMiniBrowserViewController.swift; sourceTree = "<group>"; };
 		2E40232F22B7DE4400E525C7 /* PDMBorderedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PDMBorderedView.swift; sourceTree = "<group>"; };
 		2E4A2AB52326C26F0019C6A8 /* PDMUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDMUserTests.swift; sourceTree = "<group>"; };
+		2E4A2AB72326CC6C0019C6A8 /* CreateAccountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAccountTests.swift; sourceTree = "<group>"; };
 		2E5088F12267B6DA009FF808 /* WelcomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
 		2E5088F5226908BD009FF808 /* PDMCheckbox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PDMCheckbox.swift; sourceTree = "<group>"; };
 		2E53B95322A176E800202ACD /* PatientHealthRecordDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientHealthRecordDataController.swift; sourceTree = "<group>"; };
@@ -255,6 +257,7 @@
 			isa = PBXGroup;
 			children = (
 				2E2342B8224291C500045E3A /* pdm_uiUITests.swift */,
+				2E4A2AB72326CC6C0019C6A8 /* CreateAccountTests.swift */,
 				2E2342BA224291C500045E3A /* Info.plist */,
 			);
 			path = "pdm-uiUITests";
@@ -540,6 +543,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2E2342B9224291C500045E3A /* pdm_uiUITests.swift in Sources */,
+				2E4A2AB82326CC6C0019C6A8 /* CreateAccountTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/pdm-ui.xcodeproj/project.pbxproj
+++ b/pdm-ui.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		2E3C334722988F960013A712 /* AddSourceOAuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E3C334622988F960013A712 /* AddSourceOAuthViewController.swift */; };
 		2E3C3349229892DD0013A712 /* PDMMiniBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E3C3348229892DD0013A712 /* PDMMiniBrowserViewController.swift */; };
 		2E40233022B7DE4500E525C7 /* PDMBorderedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E40232F22B7DE4400E525C7 /* PDMBorderedView.swift */; };
+		2E4A2AB62326C26F0019C6A8 /* PDMUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4A2AB52326C26F0019C6A8 /* PDMUserTests.swift */; };
 		2E5088F22267B6DA009FF808 /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5088F12267B6DA009FF808 /* WelcomeViewController.swift */; };
 		2E5088F6226908BD009FF808 /* PDMCheckbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5088F5226908BD009FF808 /* PDMCheckbox.swift */; };
 		2E53B95422A176E800202ACD /* PatientHealthRecordDataController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53B95322A176E800202ACD /* PatientHealthRecordDataController.swift */; };
@@ -108,6 +109,7 @@
 		2E3C334622988F960013A712 /* AddSourceOAuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSourceOAuthViewController.swift; sourceTree = "<group>"; };
 		2E3C3348229892DD0013A712 /* PDMMiniBrowserViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDMMiniBrowserViewController.swift; sourceTree = "<group>"; };
 		2E40232F22B7DE4400E525C7 /* PDMBorderedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PDMBorderedView.swift; sourceTree = "<group>"; };
+		2E4A2AB52326C26F0019C6A8 /* PDMUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDMUserTests.swift; sourceTree = "<group>"; };
 		2E5088F12267B6DA009FF808 /* WelcomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
 		2E5088F5226908BD009FF808 /* PDMCheckbox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PDMCheckbox.swift; sourceTree = "<group>"; };
 		2E53B95322A176E800202ACD /* PatientHealthRecordDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientHealthRecordDataController.swift; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 				2E2342AF224291C500045E3A /* Info.plist */,
 				2EA93703226F60E100513F9D /* HTTPExtensionsTests.swift */,
 				2EA9370F2278AC6700513F9D /* PatientDataManagerTests.swift */,
+				2E4A2AB52326C26F0019C6A8 /* PDMUserTests.swift */,
 				2ED98953227CEAF70034B4B6 /* PDMProfileTests.swift */,
 				2ED989552280ACB20034B4B6 /* RESTClientTests.swift */,
 			);
@@ -527,6 +530,7 @@
 				2ED98954227CEAF70034B4B6 /* PDMProfileTests.swift in Sources */,
 				2EA93704226F60E100513F9D /* HTTPExtensionsTests.swift in Sources */,
 				2ED989562280ACB20034B4B6 /* RESTClientTests.swift in Sources */,
+				2E4A2AB62326C26F0019C6A8 /* PDMUserTests.swift in Sources */,
 				2EA937102278AC6700513F9D /* PatientDataManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/pdm-ui/Backend/Models/PDMUser.swift
+++ b/pdm-ui/Backend/Models/PDMUser.swift
@@ -80,4 +80,11 @@ struct PDMUser {
         }
         self.init(fromJSON: jsonDict)
     }
+
+    /// Checks a password to ensure it meets complexity requirements.
+    /// Password should be 8-70 characters and include at least one of the following character classes: uppercase, lowercase, digit and "special" characters
+    /// The regexp is taken from the current backend config. It's somewhat unclear how well it functions.
+    static func checkComplexityOfPassword(_ password: String) -> Bool {
+        return password.range(of: "(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}", options: .regularExpression, range: nil, locale: nil) != nil
+    }
 }

--- a/pdm-ui/Backend/Models/PDMUser.swift
+++ b/pdm-ui/Backend/Models/PDMUser.swift
@@ -83,7 +83,7 @@ struct PDMUser {
 
     /// Checks a password to ensure it meets complexity requirements.
     /// Password should be 8-70 characters and include at least one of the following character classes: uppercase, lowercase, digit and "special" characters
-    /// The regexp is taken from the current backend config. It's somewhat unclear how well it functions.
+    /// The regexp is taken from the current backend config. It's somewhat unclear how well it functions within Swift's somewhat weird definition of a "character." (Specifically, if a user uses things like emojis, will that potentially make this allow a password through to the backend that it will reject?)
     static func checkComplexityOfPassword(_ password: String) -> Bool {
         return password.range(of: "(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}", options: .regularExpression, range: nil, locale: nil) != nil
     }

--- a/pdm-ui/Base.lproj/Main.storyboard
+++ b/pdm-ui/Base.lproj/Main.storyboard
@@ -20,19 +20,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Patient Data Manager" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sDd-X6-beO">
-                                <rect key="frame" x="37" y="357" width="301" height="36"/>
+                                <rect key="frame" x="37" y="373" width="301" height="36"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                 <color key="textColor" name="SelectedNav"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Collect your health data for sharing with anyone you want." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Chf-KJ-HHe">
-                                <rect key="frame" x="32" y="441" width="311" height="41"/>
+                                <rect key="frame" x="32" y="457" width="311" height="41"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LwG-Pp-QvB" customClass="PDMButton" customModule="pdm_ui" customModuleProvider="target">
-                                <rect key="frame" x="8" y="621" width="359" height="38"/>
+                                <rect key="frame" x="8" y="629" width="359" height="30"/>
                                 <state key="normal" title="Sign In"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="isButtonActive" value="NO"/>
@@ -42,13 +42,13 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="An open source project by MITRE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eZx-sf-pUU">
-                                <rect key="frame" x="60" y="514" width="255" height="21"/>
+                                <rect key="frame" x="60" y="530" width="255" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mtT-uw-y5F" customClass="PDMButton" customModule="pdm_ui" customModuleProvider="target">
-                                <rect key="frame" x="8" y="567" width="359" height="38"/>
+                                <rect key="frame" x="8" y="583" width="359" height="30"/>
                                 <state key="normal" title="Create Account"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="isButtonActive" value="YES"/>
@@ -95,7 +95,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="QoG-9Y-rYY">
-                                <rect key="frame" x="16" y="148" width="343" height="179"/>
+                                <rect key="frame" x="16" y="148" width="343" height="171"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="okf-Ss-tCp">
                                         <rect key="frame" x="0.0" y="0.0" width="343" height="20.5"/>
@@ -134,7 +134,7 @@
                                         </connections>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o9N-hh-f85" customClass="PDMButton" customModule="pdm_ui" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="141" width="343" height="38"/>
+                                        <rect key="frame" x="0.0" y="141" width="343" height="30"/>
                                         <accessibility key="accessibilityConfiguration" hint="Sign in to PDM"/>
                                         <state key="normal" title="Sign In"/>
                                         <userDefinedRuntimeAttributes>
@@ -190,7 +190,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7TL-5A-ouP" customClass="PDMButton" customModule="pdm_ui" customModuleProvider="target">
-                                <rect key="frame" x="16" y="282" width="343" height="38"/>
+                                <rect key="frame" x="16" y="282" width="343" height="30"/>
                                 <state key="normal" title="Retry"/>
                                 <connections>
                                     <action selector="retry:" destination="3dG-5s-UAs" eventType="primaryActionTriggered" id="Wbm-t2-e8r"/>
@@ -442,6 +442,7 @@
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Password status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T07-eX-wHd">
                                                 <rect key="frame" x="0.0" y="352.5" width="354" height="17"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="passwordStatus"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>

--- a/pdm-ui/ViewControllers/CreateAccountViewController.swift
+++ b/pdm-ui/ViewControllers/CreateAccountViewController.swift
@@ -97,14 +97,25 @@ class CreateAccountViewController: UIViewController {
         createAccountButton.isEnabled = !(firstNameField.isEmpty || lastNameField.isEmpty || emailField.isEmpty || passwordField.isEmpty || passwordConfirmationField.isEmpty)
     }
 
+    // adding check for password complexity, Regexp extracted from https://stackoverflow.com/questions/19605150/
+    // Length should be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character
+    func passwordComplex(psswrd :String) -> Bool {
+        var complex = false
+        let regex = "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}$"
+        if psswrd.range(of: regex, options: .regularExpression, range: nil, locale: nil) != nil {
+            complex = true
+        }
+            return complex
+    }
+    
     func updatePasswordStatus() {
         if passwordField.isEmpty {
             passwordStatusLabel.text = "Password not filled in yet"
             passwordStatusLabel.textColor = UIColor.black
         } else {
             if let password = passwordField.text, let passwordConfirmation = passwordConfirmationField.text {
-                if password.count < 6 {
-                    passwordStatusLabel.text = "Password is too short"
+                if !passwordComplex(psswrd: password) {
+                    passwordStatusLabel.text = "Complexity requirement not met"
                     passwordStatusLabel.textColor = UIColor.red
                 } else if password == passwordConfirmation {
                     passwordStatusLabel.text = "\u{2714}\u{FE0E} Passwords match"
@@ -129,6 +140,11 @@ class CreateAccountViewController: UIViewController {
         guard let password = passwordField.text, let passwordConfirmation = passwordConfirmationField.text else {
             // In this case, one of the two is blank, probably
             print("A password was nil")
+            return
+        }
+        // adding complexity guard
+        guard passwordComplex(psswrd: password) else {
+            presentAlert("Password must be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character", title: "Complexity requirement")
             return
         }
         guard password == passwordConfirmation else {

--- a/pdm-ui/ViewControllers/CreateAccountViewController.swift
+++ b/pdm-ui/ViewControllers/CreateAccountViewController.swift
@@ -97,24 +97,13 @@ class CreateAccountViewController: UIViewController {
         createAccountButton.isEnabled = !(firstNameField.isEmpty || lastNameField.isEmpty || emailField.isEmpty || passwordField.isEmpty || passwordConfirmationField.isEmpty)
     }
 
-    // adding check for password complexity, Regexp extracted from https://stackoverflow.com/questions/19605150/
-    // Length should be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character
-    func passwordComplex(psswrd :String) -> Bool {
-        var complex = false
-        let regex = "(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}"
-        if psswrd.range(of: regex, options: .regularExpression, range: nil, locale: nil) != nil {
-            complex = true
-        }
-            return complex
-    }
-    
     func updatePasswordStatus() {
         if passwordField.isEmpty {
             passwordStatusLabel.text = "Password not filled in yet"
             passwordStatusLabel.textColor = UIColor.black
         } else {
             if let password = passwordField.text, let passwordConfirmation = passwordConfirmationField.text {
-                if !passwordComplex(psswrd: password) {
+                if !PDMUser.checkComplexityOfPassword(password) {
                     passwordStatusLabel.text = "Complexity requirement not met"
                     passwordStatusLabel.textColor = UIColor.red
                 } else if password == passwordConfirmation {
@@ -143,7 +132,7 @@ class CreateAccountViewController: UIViewController {
             return
         }
         // adding complexity guard
-        guard passwordComplex(psswrd: password) else {
+        guard PDMUser.checkComplexityOfPassword(password) else {
             presentAlert("Password must be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character", title: "Complexity requirement")
             return
         }

--- a/pdm-ui/ViewControllers/CreateAccountViewController.swift
+++ b/pdm-ui/ViewControllers/CreateAccountViewController.swift
@@ -101,7 +101,7 @@ class CreateAccountViewController: UIViewController {
     // Length should be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character
     func passwordComplex(psswrd :String) -> Bool {
         var complex = false
-        let regex = "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}$"
+        let regex = "(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}"
         if psswrd.range(of: regex, options: .regularExpression, range: nil, locale: nil) != nil {
             complex = true
         }

--- a/pdm-uiTests/PDMUserTests.swift
+++ b/pdm-uiTests/PDMUserTests.swift
@@ -1,0 +1,29 @@
+//
+//  PDMUserTests.swift
+//  pdm-uiTests
+//
+//  Created by Potter, Dan on 9/9/19.
+//  Copyright © 2019 MITRE. All rights reserved.
+//
+
+import XCTest
+@testable import pdm_ui
+
+class PDMUserTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testPasswordComplexity() {
+        XCTAssert(PDMUser.checkComplexityOfPassword("p45$w0rD"))
+        XCTAssert(PDMUser.checkComplexityOfPassword("password") == false)
+        XCTAssert(PDMUser.checkComplexityOfPassword("Ab1$") == false)
+        // This is actually a kind of crummy password, but it should pass anyway
+        XCTAssert(PDMUser.checkComplexityOfPassword("!@#abcABC123"))
+    }
+}

--- a/pdm-uiTests/PDMUserTests.swift
+++ b/pdm-uiTests/PDMUserTests.swift
@@ -20,10 +20,10 @@ class PDMUserTests: XCTestCase {
     }
 
     func testPasswordComplexity() {
-        XCTAssert(PDMUser.checkComplexityOfPassword("p45$w0rD"))
-        XCTAssert(PDMUser.checkComplexityOfPassword("password") == false)
-        XCTAssert(PDMUser.checkComplexityOfPassword("Ab1$") == false)
+        XCTAssertTrue(PDMUser.checkComplexityOfPassword("p45$w0rD"))
+        XCTAssertFalse(PDMUser.checkComplexityOfPassword("password"))
+        XCTAssertFalse(PDMUser.checkComplexityOfPassword("Ab1$"))
         // This is actually a kind of crummy password, but it should pass anyway
-        XCTAssert(PDMUser.checkComplexityOfPassword("!@#abcABC123"))
+        XCTAssertTrue(PDMUser.checkComplexityOfPassword("!@#abcABC123"))
     }
 }

--- a/pdm-uiUITests/CreateAccountTests.swift
+++ b/pdm-uiUITests/CreateAccountTests.swift
@@ -1,0 +1,43 @@
+//
+//  CreateAccountTests.swift
+//  pdm-uiUITests
+//
+//  Created by Potter, Dan on 9/9/19.
+//  Copyright © 2019 MITRE. All rights reserved.
+//
+
+import XCTest
+
+class CreateAccountTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+        XCUIApplication().launch()
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        let app = XCUIApplication()
+        app.buttons["Create Account"].tap()
+
+        let elementsQuery = app.scrollViews.otherElements
+        let passwordSecureTextField = elementsQuery.children(matching: .secureTextField).matching(identifier: "Password").element(boundBy: 0)
+
+        passwordSecureTextField.tap()
+        passwordSecureTextField.typeText("bad password")
+
+        let passwordStatusLabel = elementsQuery.staticTexts["passwordStatus"]
+        XCTAssertEqual("Complexity requirement not met", passwordStatusLabel.label)
+    }
+
+}


### PR DESCRIPTION
Added checks and guards on password complexity on iOS app's create account view. Currently the password complexity is set to require 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character. 